### PR TITLE
Fix const char* warnings

### DIFF
--- a/WS2812FX.cpp
+++ b/WS2812FX.cpp
@@ -165,7 +165,7 @@ uint32_t WS2812FX::getColor(void) {
   return _color; 
 }
 
-char* WS2812FX::getModeName(uint8_t m) {
+const char* WS2812FX::getModeName(uint8_t m) {
   if(m < MODE_COUNT) {
     return _name[m];
   } else {
@@ -1156,3 +1156,4 @@ void WS2812FX::mode_fireworks_random(void) {
   _mode_color = color_wheel(random(256));
   mode_fireworks();
 }
+

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -250,7 +250,7 @@ class WS2812FX : public Adafruit_NeoPixel {
     uint32_t
       getColor(void);
 
-    char*
+    const char*
       getModeName(uint8_t m);
 
   private:
@@ -325,7 +325,7 @@ class WS2812FX : public Adafruit_NeoPixel {
     unsigned long
       _mode_last_call_time;
 
-    char*
+    const char*
       _name[MODE_COUNT];
 
     mode_ptr
@@ -333,3 +333,4 @@ class WS2812FX : public Adafruit_NeoPixel {
 };
 
 #endif
+


### PR DESCRIPTION
Hello,

Thx for your library that I use on one of my projects. Very useful and the effects are nice.
I had to fix some compilation warnings that show on arduino IDE on linux (_warning: deprecated conversion from string constant to 'char*'_ - I don't know if it happens on other OS). This is due to gcc that wants to prevent confusion between regular strings and constant strings.

Regards,
Eric