### PR TITLE
Make example work with ATmega32U4 based boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features
 
 * 44 different effects. And counting.
 * Free of any delay()
-* Tested on Arduino Nano, Uno and ESP8266.
+* Tested on Arduino Nano, Uno, Micro and ESP8266.
 * All effects with printable names - easy to use in user interfaces.
 * FX, speed and brightness controllable on the fly.
 

--- a/examples/serial_control/serial_control.ino
+++ b/examples/serial_control/serial_control.ino
@@ -33,6 +33,12 @@ void setup() {
 void loop() {
   ws2812fx.service();
 
+  // On Atmega32U4 based boards (leonardo, micro) serialEvent is not called
+  // automatically when data arrive on the serial RX. We need to do it ourself
+  #if defined(__AVR_ATmega32U4__)
+  serialEvent();
+  #endif
+
   if(cmd_complete) {
     process_command();
   }


### PR DESCRIPTION
Hello,

I'm using an Arduino micro in my project, and figured out that it doesn't call automatically serialEvent (from arduino reference guide _Currently, serialEvent() is not compatible with the Esplora, Leonardo, or Micro_). ATmega32U4 based boards handle RXTX differently since it is done by the same microcontroler as the one that run the sketch).
Tell me if something needs to be improved in this matter.

Hope this helps,
Eric