### PR TITLE
Added Fire Flickering effect

### DIFF
--- a/WS2812FX.cpp
+++ b/WS2812FX.cpp
@@ -1174,3 +1174,38 @@ void WS2812FX::mode_merry_christmas(void) {
   _counter_mode_step = (_counter_mode_step + 1) % 4;
   _mode_delay = 50 + ((75 * (uint32_t)(SPEED_MAX - _speed)) / _led_count);
 }
+
+/*
+ * Random flickering.
+ */
+void WS2812FX::mode_fire_flicker(void) {
+   mode_fire_flicker_int(3);
+}
+
+/*
+ * Random flickering, less intesity.
+ */
+void WS2812FX::mode_fire_flicker_soft(void) {
+   mode_fire_flicker_int(6);
+}
+
+void WS2812FX::mode_fire_flicker_int(int rev_intensity)
+{
+    byte p_r = (_color & 0x00FF0000) >> 16;
+    byte p_g = (_color & 0x0000FF00) >>  8;
+    byte p_b = (_color & 0x000000FF) >>  0;
+    byte flicker_val = max(p_r,max(p_g, p_b))/rev_intensity;
+    for(uint16_t i=0; i < _led_count; i++)
+    {
+      int flicker = random(0,flicker_val);
+      int r1 = p_r-flicker;
+      int g1 = p_g-flicker;
+      int b1 = p_b-flicker;
+      if(g1<0) g1=0;
+      if(r1<0) r1=0;
+      if(b1<0) b1=0;
+      Adafruit_NeoPixel::setPixelColor(i,r1,g1, b1);
+    }
+    Adafruit_NeoPixel::show();
+    _mode_delay = 10 + ((500 * (uint32_t)(SPEED_MAX - _speed)) / SPEED_MAX);
+}

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -311,10 +311,10 @@ class WS2812FX : public Adafruit_NeoPixel {
       mode_comet(void),
       mode_fireworks(void),
       mode_fireworks_random(void),
-      mode_merry_christmas(void);
+      mode_merry_christmas(void),
       mode_fire_flicker(void),
       mode_fire_flicker_soft(void),
-      mode_fire_flicker_int(int),
+      mode_fire_flicker_int(int);
 
     boolean
       _running;

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -112,6 +112,8 @@
 #define FX_MODE_FIREWORKS               42
 #define FX_MODE_FIREWORKS_RANDOM        43
 #define FX_MODE_MERRY_CHRISTMAS         44
+#define FX_MODE_FIRE_FLICKER            45
+#define FX_MODE_FIRE_FLICKER_SOFT       46
 
 
 class WS2812FX : public Adafruit_NeoPixel {
@@ -166,6 +168,8 @@ class WS2812FX : public Adafruit_NeoPixel {
       _mode[FX_MODE_FIREWORKS]             = &WS2812FX::mode_fireworks;
       _mode[FX_MODE_FIREWORKS_RANDOM]      = &WS2812FX::mode_fireworks_random;
       _mode[FX_MODE_MERRY_CHRISTMAS]       = &WS2812FX::mode_merry_christmas;
+      _mode[FX_MODE_FIRE_FLICKER]          = &WS2812FX::mode_fire_flicker;
+      _mode[FX_MODE_FIRE_FLICKER_SOFT]     = &WS2812FX::mode_fire_flicker_soft;
 
       _name[FX_MODE_STATIC]                = "Static";
       _name[FX_MODE_BLINK]                 = "Blink";
@@ -212,6 +216,9 @@ class WS2812FX : public Adafruit_NeoPixel {
       _name[FX_MODE_FIREWORKS]             = "Fireworks";
       _name[FX_MODE_FIREWORKS_RANDOM]      = "Fireworks Random";
       _name[FX_MODE_MERRY_CHRISTMAS]       = "Merry Christmas";
+      _name[FX_MODE_FIRE_FLICKER]          = "Fire Flicker";
+      _name[FX_MODE_FIRE_FLICKER_SOFT]     = "Fire Flicker (soft)";
+      
 
       _mode_index = DEFAULT_MODE;
       _speed = DEFAULT_SPEED;
@@ -305,6 +312,9 @@ class WS2812FX : public Adafruit_NeoPixel {
       mode_fireworks(void),
       mode_fireworks_random(void),
       mode_merry_christmas(void);
+      mode_fire_flicker(void),
+      mode_fire_flicker_soft(void),
+      mode_fire_flicker_int(int),
 
     boolean
       _running;


### PR DESCRIPTION
Random changes in brightness per single pixel make a nice flame effect, FX 45 is more intense like a campfire while FX 46 is more like a candle. Best with passive lights and few LEDs.