### PR TITLE
Added mode_static_white for RGBW pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library features a variety of blinken effects for the WS2811/WS2812/NeoPixe
 Features
 --------
 
-* 47 different effects. And counting.
+* 47 different RGB effects. 1 RGBW effect. And counting.
 * Free of any delay()
 * Tested on Arduino Nano, Uno, Micro and ESP8266.
 * All effects with printable names - easy to use in user interfaces.
@@ -101,6 +101,7 @@ Effects
 * **Merry Christmas** - Alternating green/red pixels running.
 * **Fire Flicker** - Fire flickering effect. Like in harsh wind.
 * **Fire Flicker (soft)** - Fire flickering effect. Runs slower/softer.
+* **Static White (RGBW)** - Glorious white light from those white LEDs on RGBW pixels.
 
 
 Projects using WS2812FX

--- a/WS2812FX.cpp
+++ b/WS2812FX.cpp
@@ -47,6 +47,7 @@
   2016-06-04   2 new fx, fixed setColor (now also resets _mode_color)
   2017-02-02   added external trigger functionality (e.g. for sound-to-light)
   2017-02-02   removed "blackout" on mode, speed or color-change
+  2017-05-09   added static white fx for RGBW pixels
 
 */
 
@@ -1221,4 +1222,16 @@ void WS2812FX::mode_fire_flicker_int(int rev_intensity)
     }
     Adafruit_NeoPixel::show();
     _mode_delay = 10 + ((500 * (uint32_t)(SPEED_MAX - _speed)) / SPEED_MAX);
+}
+
+/*
+ * No blinking. Just plain old white static light (RGBW).
+ */
+void WS2812FX::mode_static_white(void) {
+  for(uint16_t i=0; i < _led_count; i++) {
+    Adafruit_NeoPixel::setPixelColor(i, 0, 0, 0, _brightness);
+  }
+  Adafruit_NeoPixel::show();
+
+  _mode_delay = 50;
 }

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -46,6 +46,7 @@
   2016-06-03   Code cleanup, minor improvements, new modes
   2016-06-04   2 new fx, fixed setColor (now also resets _mode_color)
   2017-02-02   added external trigger functionality (e.g. for sound-to-light)
+  2017-05-09   added static white fx for RGBW pixels
 
 */
 
@@ -115,6 +116,7 @@
 #define FX_MODE_MERRY_CHRISTMAS         44
 #define FX_MODE_FIRE_FLICKER            45
 #define FX_MODE_FIRE_FLICKER_SOFT       46
+#define FX_MODE_STATIC                  47
 
 
 class WS2812FX : public Adafruit_NeoPixel {
@@ -171,6 +173,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       _mode[FX_MODE_MERRY_CHRISTMAS]       = &WS2812FX::mode_merry_christmas;
       _mode[FX_MODE_FIRE_FLICKER]          = &WS2812FX::mode_fire_flicker;
       _mode[FX_MODE_FIRE_FLICKER_SOFT]     = &WS2812FX::mode_fire_flicker_soft;
+      _mode[FX_MODE_STATIC_WHITE]          = &WS2812FX::mode_static_white;
 
       _name[FX_MODE_STATIC]                = "Static";
       _name[FX_MODE_BLINK]                 = "Blink";
@@ -219,6 +222,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       _name[FX_MODE_MERRY_CHRISTMAS]       = "Merry Christmas";
       _name[FX_MODE_FIRE_FLICKER]          = "Fire Flicker";
       _name[FX_MODE_FIRE_FLICKER_SOFT]     = "Fire Flicker (soft)";
+      _name[FX_MODE_STATIC_WHITE]          = "Static White (RGBW)";
       
 
       _mode_index = DEFAULT_MODE;
@@ -316,7 +320,8 @@ class WS2812FX : public Adafruit_NeoPixel {
       mode_merry_christmas(void),
       mode_fire_flicker(void),
       mode_fire_flicker_soft(void),
-      mode_fire_flicker_int(int);
+      mode_fire_flicker_int(int),
+      mode_static_white(void);
 
     boolean
       _running,

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -67,7 +67,7 @@
 #define BRIGHTNESS_MIN 0
 #define BRIGHTNESS_MAX 255
 
-#define MODE_COUNT 47
+#define MODE_COUNT 48
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -116,7 +116,7 @@
 #define FX_MODE_MERRY_CHRISTMAS         44
 #define FX_MODE_FIRE_FLICKER            45
 #define FX_MODE_FIRE_FLICKER_SOFT       46
-#define FX_MODE_STATIC                  47
+#define FX_MODE_STATIC_WHITE            47
 
 
 class WS2812FX : public Adafruit_NeoPixel {


### PR DESCRIPTION
Quick and dirty for RGBW support in static mode. Leverages` _brightness` to set the white LED brightness for RGBW pixels.