### PR TITLE
Change LED count while running

### DIFF
--- a/WS2812FX.cpp
+++ b/WS2812FX.cpp
@@ -10,7 +10,7 @@
     * WS2812FX can be used as drop-in replacement for Adafruit Neopixel Library
 
   NOTES
-    * Uses the Adafruit Neopixel library. Get it here: 
+    * Uses the Adafruit Neopixel library. Get it here:
       https://github.com/adafruit/Adafruit_NeoPixel
 
 
@@ -19,7 +19,7 @@
 
   The MIT License (MIT)
 
-  Copyright (c) 2016  Harm Aldick 
+  Copyright (c) 2016  Harm Aldick
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -148,8 +148,27 @@ void WS2812FX::decreaseBrightness(uint8_t s) {
   setBrightness(s);
 }
 
+void WS2812FX::setLEDCount(uint8_t b) {
+  _led_count = b;
+
+  for(uint16_t i=0; i < _led_count + 1000; i++) {
+    Adafruit_NeoPixel::setPixelColor(i, 0);
+  }
+  Adafruit_NeoPixel::show();
+}
+
+void WS2812FX::increaseLEDCount(uint8_t s) {
+  s = _led_count + s;
+  setLEDCount(s);
+}
+
+void WS2812FX::decreaseLEDCount(uint8_t s) {
+  s = _led_count - s;
+  setLEDCount(s);
+}
+
 boolean WS2812FX::isRunning() {
-  return _running; 
+  return _running;
 }
 
 uint8_t WS2812FX::getMode(void) {
@@ -164,12 +183,16 @@ uint8_t WS2812FX::getBrightness(void) {
   return _brightness;
 }
 
+uint8_t WS2812FX::getLEDCount(void) {
+  return _led_count;
+}
+
 uint8_t WS2812FX::getModeCount(void) {
   return MODE_COUNT;
 }
 
 uint32_t WS2812FX::getColor(void) {
-  return _color; 
+  return _color;
 }
 
 const char* WS2812FX::getModeName(uint8_t m) {
@@ -310,7 +333,7 @@ void WS2812FX::mode_random_color(void) {
   for(uint16_t i=0; i < _led_count; i++) {
     Adafruit_NeoPixel::setPixelColor(i, color_wheel(_mode_color));
   }
-  
+
   Adafruit_NeoPixel::show();
   _mode_delay = 100 + ((5000 * (uint32_t)(SPEED_MAX - _speed)) / SPEED_MAX);
 }
@@ -371,7 +394,7 @@ void WS2812FX::mode_breath(void) {
   if(breath_brightness == breath_brightness_steps[_counter_mode_step]) {
     _counter_mode_step = (_counter_mode_step + 1) % (sizeof(breath_brightness_steps)/sizeof(uint8_t));
   }
-  
+
   for(uint16_t i=0; i < _led_count; i++) {
     Adafruit_NeoPixel::setPixelColor(i, _color);           // set all LEDs to selected color
   }

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -1,24 +1,36 @@
 /*
   WS2812FX.h - Library for WS2812 LED effects.
+
   Harm Aldick - 2016
   www.aldick.org
+
+
   FEATURES
     * A lot of blinken modes and counting
     * WS2812FX can be used as drop-in replacement for Adafruit Neopixel Library
+
   NOTES
     * Uses the Adafruit Neopixel library. Get it here:
       https://github.com/adafruit/Adafruit_NeoPixel
+
+
+
   LICENSE
+
   The MIT License (MIT)
+
   Copyright (c) 2016  Harm Aldick
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,11 +38,15 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
+
+
   CHANGELOG
+
   2016-05-28   Initial beta release
   2016-06-03   Code cleanup, minor improvements, new modes
   2016-06-04   2 new fx, fixed setColor (now also resets _mode_color)
   2017-02-02   added external trigger functionality (e.g. for sound-to-light)
+
 */
 
 #ifndef WS2812FX_h

--- a/WS2812FX.h
+++ b/WS2812FX.h
@@ -1,36 +1,24 @@
 /*
   WS2812FX.h - Library for WS2812 LED effects.
-  
   Harm Aldick - 2016
   www.aldick.org
-
-
   FEATURES
     * A lot of blinken modes and counting
     * WS2812FX can be used as drop-in replacement for Adafruit Neopixel Library
-
   NOTES
-    * Uses the Adafruit Neopixel library. Get it here: 
+    * Uses the Adafruit Neopixel library. Get it here:
       https://github.com/adafruit/Adafruit_NeoPixel
-
-
-
   LICENSE
-
   The MIT License (MIT)
-
-  Copyright (c) 2016  Harm Aldick 
-
+  Copyright (c) 2016  Harm Aldick
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -38,15 +26,11 @@
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
-
-
   CHANGELOG
-
   2016-05-28   Initial beta release
   2016-06-03   Code cleanup, minor improvements, new modes
   2016-06-04   2 new fx, fixed setColor (now also resets _mode_color)
   2017-02-02   added external trigger functionality (e.g. for sound-to-light)
-
 */
 
 #ifndef WS2812FX_h
@@ -219,7 +203,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       _name[FX_MODE_MERRY_CHRISTMAS]       = "Merry Christmas";
       _name[FX_MODE_FIRE_FLICKER]          = "Fire Flicker";
       _name[FX_MODE_FIRE_FLICKER_SOFT]     = "Fire Flicker (soft)";
-      
+
 
       _mode_index = DEFAULT_MODE;
       _speed = DEFAULT_SPEED;
@@ -248,18 +232,23 @@ class WS2812FX : public Adafruit_NeoPixel {
       setBrightness(uint8_t b),
       increaseBrightness(uint8_t s),
       decreaseBrightness(uint8_t s),
+      setLEDCount(uint8_t b),
+      increaseLEDCount(uint8_t s),
+      decreaseLEDCount(uint8_t s),
       trigger(void);
 
-    boolean 
+    boolean
       isRunning(void);
 
     uint8_t
       getMode(void),
       getSpeed(void),
       getBrightness(void),
-      getModeCount(void);
+      getModeCount(void),
+      getLEDCount(void);
 
     uint32_t
+      color_wheel(uint8_t),
       getColor(void);
 
     const char*
@@ -332,7 +321,6 @@ class WS2812FX : public Adafruit_NeoPixel {
       _led_count;
 
     uint32_t
-      color_wheel(uint8_t),
       _color,
       _counter_mode_call,
       _counter_mode_step,


### PR DESCRIPTION
I added functions to adjust the LED count on the fly. That way I can have a few controllers programmed and ready to just plug into a strip of LEDs and can adjust the number of leds with the controller and keep on going.  No need to modify the code, compile and reflash firmware.