### PR TITLE
Use latest Adafruit NeoPixel library on pio (Fixes #45)

### DIFF
--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
   "dependencies": [
     {
       "name": "Adafruit NeoPixel",
-      "version": "~1.0.6"
+      "version": "~1.1.2"
     }
   ]
 }


### PR DESCRIPTION
Updated library.json (for platformio) to use the latest Adafruit NeoPixel library. This fixes #45 (and possible some other problems)