### PR TITLE
Version Bump to make platformio reread the library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "name": "Harm Aldick",
     "url": "https://github.com/kitesurfer1404/WS2812FX"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "downloadUrl": "https://github.com/kitesurfer1404/WS2812FX/archive/master.zip",
   "export": {
     "include": "WS2812FX-master"


### PR DESCRIPTION
Sorry, #45 was not enough, because library.json is not reimported by platformio unless the version of the library itself is changed.

So I updated the version from 1.0.0 to 1.0.1.

