### PR TITLE
Add pause / resume functions

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -28,6 +28,8 @@ init	KEYWORD2
 service	KEYWORD2
 start	KEYWORD2
 stop	KEYWORD2
+pause	KEYWORD2
+resume	KEYWORD2
 speed	KEYWORD2
 mode	KEYWORD2
 options	KEYWORD2

--- a/src/WS2812FX.cpp
+++ b/src/WS2812FX.cpp
@@ -139,6 +139,14 @@ void WS2812FX::stop() {
   strip_off();
 }
 
+void WS2812FX::pause() {
+  _running = false;
+}
+
+void WS2812FX::resume() {
+  _running = true;
+}
+
 void WS2812FX::trigger() {
   _triggered = true;
 }

--- a/src/WS2812FX.h
+++ b/src/WS2812FX.h
@@ -410,6 +410,8 @@ class WS2812FX : public Adafruit_NeoPixel {
       service(void),
       start(void),
       stop(void),
+      pause(void),
+      resume(void),
       strip_off(void),
       fade_out(void),
       setMode(uint8_t m),


### PR DESCRIPTION
`pause` halts the current effect mode without clearing the pixel strip.  
`resume` starts the currently set effect mode without resetting the runtime.
