### PR TITLE
Add ON / OFF / PAUSE / RESUME to webinterface 

### DIFF
--- a/examples/ws2812fx_segments_web/index.html.cpp
+++ b/examples/ws2812fx_segments_web/index.html.cpp
@@ -91,6 +91,14 @@ char index_html[] PROGMEM = R"=====(
           <i class="material-icons left">cloud_upload</i>Save</a>
         <a class="waves-effect waves-light btn" onclick="buildCode()">
           <i class="material-icons left">code</i>Code</a>
+        <a class="waves-effect waves-light btn" onclick="LED_pause()">
+          <i class="material-icons left">pause</i>Pause</a>          
+        <a class="waves-effect waves-light btn" onclick="LED_resume()">
+          <i class="material-icons left">replay</i>Play</a>
+        <a class="waves-effect waves-light btn" onclick="LED_on()">
+          <i class="material-icons left">blur_on</i>ON</a>  
+        <a class="waves-effect waves-light btn" onclick="LED_off()">
+          <i class="material-icons left">blur_off</i>OFF</a> 
       </div>
     </div>
   </div>
@@ -339,6 +347,66 @@ char index_html[] PROGMEM = R"=====(
         });
 
         updateWidgets();
+      });
+    }
+
+    // PAUSE
+    function LED_pause() {
+      jQuery.ajax({
+        url: "runcontrol",
+        type: "POST",
+        data: "pause",
+        dataType: "json",
+        contentType: "application/json; charset=utf-8",
+//      contentType: "application/x-www-form-urlencoded; charset=utf-8",
+        success: function() {
+          console.log(data);
+        }
+      });
+    }
+
+    // Resume after Pause
+    function LED_resume() {
+      jQuery.ajax({
+        url: "runcontrol",
+        type: "POST",
+        data: "resume",
+        dataType: "json",
+        contentType: "application/json; charset=utf-8",
+//      contentType: "application/x-www-form-urlencoded; charset=utf-8",
+        success: function() {
+          console.log(data);
+        }
+      });
+    }
+
+    // Switch strip on
+    function LED_on() {
+      jQuery.ajax({
+        url: "runcontrol",
+        type: "POST",
+        data: "run",
+        dataType: "json",
+        contentType: "application/json; charset=utf-8",
+//      contentType: "application/x-www-form-urlencoded; charset=utf-8",
+        success: function() {
+          console.log(data);
+        }
+      });
+    }
+
+     // Switch Strip off
+    function LED_off() {
+      jQuery.ajax({
+        url: "runcontrol",
+        type: "POST",
+        data: "stop",
+        dataType: "json",
+        contentType: "application/json; charset=utf-8",
+//      contentType: "application/x-www-form-urlencoded; charset=utf-8",
+        success: function() {
+          console.log(data);
+        }
       });
     }
 

--- a/examples/ws2812fx_segments_web/ws2812fx_segments_web.ino
+++ b/examples/ws2812fx_segments_web/ws2812fx_segments_web.ino
@@ -137,6 +137,25 @@ void setup() {
     server.send(200, "application/json", json);
     free(json);
   });
+  
+  // control Run / stop / pause / resume
+  server.on("/runcontrol", HTTP_POST, [](){
+String data = server.arg("plain");
+    //Serial.println(data);
+    if (data == "pause"){
+     ws2812fx.pause(); 
+    }
+    if (data == "resume"){
+     ws2812fx.resume(); 
+    }
+    if (data == "run"){
+     ws2812fx.start(); 
+    }
+    if (data == "stop"){
+     ws2812fx.stop(); 
+    }
+    server.send(200, "text/plain", "OK");
+  });
 
   // receive the segment info in JSON format and setup the WS2812 strip
   server.on("/setsegments", HTTP_POST, [](){

--- a/src/WS2812FX.cpp
+++ b/src/WS2812FX.cpp
@@ -142,6 +142,7 @@ void WS2812FX::stop() {
 void WS2812FX::pause() {
   _running = false;
 }
+
 void WS2812FX::resume() {
   _running = true;
 }

--- a/src/WS2812FX.cpp
+++ b/src/WS2812FX.cpp
@@ -139,6 +139,13 @@ void WS2812FX::stop() {
   strip_off();
 }
 
+void WS2812FX::pause() {
+  _running = false;
+}
+void WS2812FX::resume() {
+  _running = true;
+}
+
 void WS2812FX::trigger() {
   _triggered = true;
 }

--- a/src/WS2812FX.h
+++ b/src/WS2812FX.h
@@ -409,6 +409,8 @@ class WS2812FX : public Adafruit_NeoPixel {
       service(void),
       start(void),
       stop(void),
+      pause(void),
+      resume(void),
       strip_off(void),
       fade_out(void),
       setMode(uint8_t m),


### PR DESCRIPTION
I added a Play / Pause and ON / OFF Button to the webinterface.
Borrowed code from FloEdelmann from #118
This PR enables to switch the LEDs on or off completely (reset runtime) from the webinterface ans also only Pause or resume the effect (via #118 )
I'm not sure if the way i implemented it is the best and shortest way to do it, but it works great and is essential for my usage scenario.