### PR TITLE
Added function moveSegment.

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -69,6 +69,7 @@ getColor	KEYWORD2
 getColors	KEYWORD2
 getOptions	KEYWORD2
 setOptions	KEYWORD2
+moveSegment	KEYWORD2
 getNumSegments	KEYWORD2
 setNumSegments	KEYWORD2
 getSegment	KEYWORD2

--- a/src/WS2812FX.cpp
+++ b/src/WS2812FX.cpp
@@ -353,6 +353,15 @@ const __FlashStringHelper* WS2812FX::getModeName(uint8_t m) {
   }
 }
 
+void WS2812FX::moveSegment(uint8_t n,uint16_t start){
+	if(n < (sizeof(_segments) / sizeof(_segments[0]))) {
+		if(n + 1 > _num_segments) _num_segments = n + 1;
+			int len = _segments[n].stop-_segments[n].start;
+			_segments[n].start = start;
+		    _segments[n].stop = start+len;
+	}	
+}
+
 void WS2812FX::setSegment(uint8_t n, uint16_t start, uint16_t stop, uint8_t mode, uint32_t color, uint16_t speed, bool reverse) {
   uint32_t colors[] = {color, 0, 0};
   setSegment(n, start, stop, mode, colors, speed, reverse);

--- a/src/WS2812FX.h
+++ b/src/WS2812FX.h
@@ -438,6 +438,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       setSegment(uint8_t n, uint16_t start, uint16_t stop, uint8_t mode, uint32_t color, uint16_t speed, bool reverse),
       setSegment(uint8_t n, uint16_t start, uint16_t stop, uint8_t mode, const uint32_t colors[], uint16_t speed, bool reverse),
       setSegment(uint8_t n, uint16_t start, uint16_t stop, uint8_t mode, const uint32_t colors[], uint16_t speed, uint8_t options),
+	  moveSegment(uint8_t n,uint16_t start),
       resetSegments(),
       resetSegmentRuntimes(),
       resetSegmentRuntime(uint8_t),


### PR DESCRIPTION
This function allows you to move an effect on the strip. This makes it possible to park an effect outside the strip, and later back onto the strip again.

This solves the following problem to me:

I have two stripes running in sync. At a certain time, I want to temporarily replace a effect on the first stripe.
After a while, I want to return tu the old effect.
Using the setMode function will desynchronize the effects, as the effect on the first stripe will be restarted, while the same effect on the second stripe will continune iwith his sequence.