### PR TITLE
Lift platform restriction for pio users

### DIFF
--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "include": "WS2812FX-master"
   },
   "frameworks": "arduino",
-  "platforms": "espressif8266",
+  "platforms": "*",
   "repository": {
     "type": "git",
     "url": "https://github.com/kitesurfer1404/WS2812FX.git"


### PR DESCRIPTION
Given that there are example sketches for ESP32 and my tests confirm
that the library works on that architecture, enable it in platform.io's
configuration file.

I have tested this library with a Feather Huzzah32 device using platformio.

Note that the Arduino IDE configuration file does not restrict the architecture at all. So is this the right way?