### PR TITLE
Enhanced esp8266_webinterface example.

### DIFF
--- a/examples/esp8266_webinterface/esp8266_webinterface.ino
+++ b/examples/esp8266_webinterface/esp8266_webinterface.ino
@@ -250,8 +250,11 @@ void srv_handle_set() {
     if(server.argName(i) == "s") {
       if(server.arg(i)[0] == '-') {
         ws2812fx.setSpeed(max(ws2812fx.getSpeed(), 5) * 1.2);
-      } else {
+      } else if(server.arg(i)[0] == ' ') {
         ws2812fx.setSpeed(ws2812fx.getSpeed() * 0.8);
+      } else {
+        uint16_t tmp = (uint16_t) strtol(server.arg(i).c_str(), NULL, 10);
+        ws2812fx.setSpeed(tmp);
       }
       Serial.print("speed is "); Serial.println(ws2812fx.getSpeed());
     }


### PR DESCRIPTION
For many applications the esp8266_webinterface example is usable out of the box and there is no need to setup an own project in a lot of cases.
But this time I had the need to set the speed directly from a remote device. So I had to add the missing request parameter handling to the set handler.