### PR TITLE
Multiple Strand Aggregation Part 1: Composition

### DIFF
--- a/examples/ws2812fx_limit_current/ws2812fx_limit_current.ino
+++ b/examples/ws2812fx_limit_current/ws2812fx_limit_current.ino
@@ -186,15 +186,15 @@ void myCustomShow(void) {
       uint32_t estimatedCurrent = ((intensitySum * INCREMENTAL_CURRENT) / 1000) + QUIESCENT_CURRENT;
       Serial.print("estimatedCurrent="); Serial.print(estimatedCurrent); Serial.println("mA");
 
-      uint8_t oldBrightness = ws2812fx.Adafruit_NeoPixel::getBrightness();
+      uint8_t oldBrightness = ws2812fx.getBrightness();
       Serial.print("old brightness="); Serial.println(oldBrightness);
 
       uint8_t scaleFactor = (MAX_INTENSITY_SUM * 256) / intensitySum; // brightness scaling factor
       uint8_t newBrightness = constrain(((oldBrightness * scaleFactor) / 256), BRIGHTNESS_MIN, BRIGHTNESS_MAX);
       Serial.print("new brightness="); Serial.println(newBrightness);
 
-      // call the Adafruit_Neopixel::setBrightness() function, because the WS2812FX::setBrightness() function calls show(), which we don't want.
-      ws2812fx.Adafruit_NeoPixel::setBrightness(newBrightness);
+      // call the setBrightnessDirect() function, because the WS2812FX::setBrightness() function calls show(), which we don't want.
+      ws2812fx.setBrightnessDirect(newBrightness);
 
       // optionally, for verification, recalculate the intensity sum and current estimate
       intensitySum = ws2812fx.intensitySum();
@@ -204,5 +204,5 @@ void myCustomShow(void) {
     }
     lastSum = intensitySum;
   }
-  ws2812fx.Adafruit_NeoPixel::show();
+  ws2812fx.showDirect();
 }

--- a/src/WS2812FX.cpp
+++ b/src/WS2812FX.cpp
@@ -1545,7 +1545,7 @@ uint16_t WS2812FX::mode_circus_combustus(void) {
  */
 uint16_t WS2812FX::mode_icu(void) {
   uint16_t dest = SEGMENT_RUNTIME.counter_mode_step & 0xFFFF;
- 
+
   setPixelColor(SEGMENT.start + dest, SEGMENT.colors[0]);
   setPixelColor(SEGMENT.start + dest + SEGMENT_LENGTH/2, SEGMENT.colors[0]);
 

--- a/src/WS2812FX.h
+++ b/src/WS2812FX.h
@@ -305,7 +305,7 @@ static const __FlashStringHelper* _names[] = {
   FSH(name_59)
 };
 
-class WS2812FX : public Adafruit_NeoPixel {
+class WS2812FX {
 
   typedef uint16_t (WS2812FX::*mode_ptr)(void);
 
@@ -330,7 +330,9 @@ class WS2812FX : public Adafruit_NeoPixel {
       uint16_t aux_param3; // auxilary param (usually stores a segment index)
     } segment_runtime;
 
-    WS2812FX(uint16_t n, uint8_t p, neoPixelType t) : Adafruit_NeoPixel(n, p, t) {
+    WS2812FX(uint16_t n, uint8_t p, neoPixelType t) {
+      Adafruit_NeoPixel strand(n, p, t);
+      _strand = &strand;
       _mode[FX_MODE_STATIC]                  = &WS2812FX::mode_static;
       _mode[FX_MODE_BLINK]                   = &WS2812FX::mode_blink;
       _mode[FX_MODE_COLOR_WIPE]              = &WS2812FX::mode_color_wipe;
@@ -400,7 +402,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       _mode[FX_MODE_CUSTOM_2]                = &WS2812FX::mode_custom_2;
       _mode[FX_MODE_CUSTOM_3]                = &WS2812FX::mode_custom_3;
 
-      brightness = DEFAULT_BRIGHTNESS + 1; // Adafruit_NeoPixel internally offsets brightness by 1
+      _strand->setBrightness(DEFAULT_BRIGHTNESS + 1); // Adafruit_NeoPixel internally offsets brightness by 1
       _running = false;
       _num_segments = 1;
       _segments[0].mode = DEFAULT_MODE;
@@ -408,6 +410,10 @@ class WS2812FX : public Adafruit_NeoPixel {
       _segments[0].start = 0;
       _segments[0].stop = n - 1;
       _segments[0].speed = DEFAULT_SPEED;
+      _strand_offset = {
+        (uint8_t)((t >> 6) & 0b11),  // Taken from Adafruit calculation
+        (uint8_t)((t >> 4) & 0b11) // Taken from Adafruit calculation
+      };
       resetSegmentRuntimes();
     }
 
@@ -437,6 +443,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       setColor(uint8_t seg, uint32_t c),
       setColors(uint8_t seg, uint32_t* c),
       setBrightness(uint8_t b),
+      setBrightnessDirect(uint8_t b),
       increaseBrightness(uint8_t s),
       decreaseBrightness(uint8_t s),
       setLength(uint16_t b),
@@ -455,6 +462,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
       setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t w),
       copyPixels(uint16_t d, uint16_t s, uint16_t c),
+      showDirect(void),
       show(void);
 
     boolean
@@ -468,6 +476,7 @@ class WS2812FX : public Adafruit_NeoPixel {
     uint8_t
       random8(void),
       random8(uint8_t),
+      getBrightness(void),
       getMode(void),
       getMode(uint8_t),
       getModeCount(void),
@@ -490,6 +499,7 @@ class WS2812FX : public Adafruit_NeoPixel {
       color_wheel(uint8_t),
       getColor(void),
       getColor(uint8_t),
+      getPixelColor(uint16_t),
       intensitySum(void);
 
     uint32_t* getColors(uint8_t);
@@ -588,6 +598,8 @@ class WS2812FX : public Adafruit_NeoPixel {
       mode_custom_3(void);
 
   private:
+    Adafruit_NeoPixel* _strand;
+
     uint16_t _rand16seed;
     uint16_t (*customModes[MAX_CUSTOM_MODES])(void) {
       []{ return (uint16_t)1000; },
@@ -610,6 +622,11 @@ class WS2812FX : public Adafruit_NeoPixel {
       { 0, 7, DEFAULT_SPEED, FX_MODE_STATIC, NO_OPTIONS, {DEFAULT_COLOR}}
     };
     segment_runtime _segment_runtimes[MAX_NUM_SEGMENTS]; // SRAM footprint: 16 bytes per element
+
+    struct Strand_offsets { // Adafruit offset values
+      uint8_t           rOffset;    ///< Red index within each 3- or 4-byte pixel
+      uint8_t           wOffset;    ///< Index of white (==rOffset if no white)
+    } _strand_offset;
 };
 
 #endif

--- a/src/WS2812FX.h
+++ b/src/WS2812FX.h
@@ -121,7 +121,7 @@
 #define FX_MODE_BLINK                    1
 #define FX_MODE_BREATH                   2
 #define FX_MODE_COLOR_WIPE               3
-#define FX_MODE_COLOR_WIPE_INV           4 
+#define FX_MODE_COLOR_WIPE_INV           4
 #define FX_MODE_COLOR_WIPE_REV           5
 #define FX_MODE_COLOR_WIPE_REV_INV       6
 #define FX_MODE_COLOR_WIPE_RANDOM        7
@@ -308,7 +308,7 @@ static const __FlashStringHelper* _names[] = {
 class WS2812FX : public Adafruit_NeoPixel {
 
   typedef uint16_t (WS2812FX::*mode_ptr)(void);
-  
+
   // segment parameters
   public:
     typedef struct Segment { // 20 bytes


### PR DESCRIPTION
Hey @kitesurfer1404 and @moose4lord,

Thanks for this fantastic library. This is the best non-blocking LED library I have found.

I have a use-case where I would like to have multiple strips appear as a single strip but use different Arduino data out pins. I was thinking that with minimally invasive changes I could refactor this library to support multiple strands across a single animation. The code changes would look like this:

1. Replace inheritance of `WS2812FX` on `AdafruitNeoPixel` for composition and initialize `AdafruitNeoPixel` in the constructor. (this PR)
2. Support passing in an `AdafruitNeoPixel` strip in `WS2812FX` initialize. Have an overloaded constructor where `WS2812FX(uint16_t n, uint8_t p, neoPixelType t)` would call `WS2812FX(AdafruitNeoPixel strip)`. This will require also probably passing in the `neoPixelType`, as there's no way to pull out the `neoPixelType` from `AdafruitNeoPixel`. There would probably be some bug where different strands with different `neoPixelTypes` could have unexpected behavior.
3. Support passing in an array of strips into `WS2812FX`. Something like `WS2812FX(AdafruitNeoPixel strip[])`. The `getLength()` call will add all of the individual strands and the `setPixelColor` will check the strand lengths and set the appropriate underlying strand pixel. We would probably default all existing non-individual-pixel code to just access the first strand such as `getBrightness`.

All existing usecases would still continue to work by still supporting a `WS2812FX(uint16_t n, uint8_t p, neoPixelType t)` constructor and users could still use the `WS2812FX` as if it is one-to-one with `AdafruitNeoPixel`.

Thoughts?

Thanks for your consideration!