### PR TITLE
Example code: hard coded values -> define

### DIFF
--- a/examples/ws2812fx_segments_OTA/ws2812fx_segments_OTA.ino
+++ b/examples/ws2812fx_segments_OTA/ws2812fx_segments_OTA.ino
@@ -97,7 +97,7 @@ void setup() {
   ws2812fx.setBrightness(127);
 
   // parameters: index, start, stop, mode, color, speed, reverse
-  ws2812fx.setSegment(0, 0, 29, 9, (const uint32_t[]) {0xff0000, 0x000000, 0x000000}, 1000, false);
+  ws2812fx.setSegment(0, 0, LED_COUNT-1, FX_MODE_SINGLE_DYNAMIC, (const uint32_t[]) {0xff0000, 0x000000, 0x000000}, 1000, false);
   ws2812fx.start();
 }
 

--- a/examples/ws2812fx_segments_web/ws2812fx_segments_web.ino
+++ b/examples/ws2812fx_segments_web/ws2812fx_segments_web.ino
@@ -78,7 +78,7 @@ struct Preset {
   int  brightness = 64;
   int  numSegments = 1;
   WS2812FX::Segment segments[MAX_NUM_SEGMENTS] = {
-    {0, LED_COUNT - 1, 1000, 0, 0, {RED, GREEN, BLUE}}
+    {0, LED_COUNT - 1, 1000, FX_MODE_STATIC, NO_OPTIONS, {RED, GREEN, BLUE}}
   };
 };
 Preset preset; // note: "preset" is a Preset data struct


### PR DESCRIPTION
In some example code files, values are hard coded instead of using the appropriate defines