### PR TITLE
Remove conflicted fields

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,21 +7,14 @@
     "url": "https://github.com/kitesurfer1404/WS2812FX"
   },
   "version": "1.3.5",
-  "downloadUrl": "https://github.com/kitesurfer1404/WS2812FX/archive/master.zip",
-  "export": {
-    "include": "WS2812FX-master"
-  },
   "frameworks": "arduino",
   "platforms": "*",
   "repository": {
     "type": "git",
     "url": "https://github.com/kitesurfer1404/WS2812FX.git"
   },
-  "dependencies": [
-    {
-      "name": "Adafruit NeoPixel",
-      "version": ">=1.1.7"
-    }
-  ],
+  "dependencies": {
+    "adafruit/Adafruit NeoPixel": ">=1.1.7"
+  },
   "headers": "WS2812FX.h"
 }


### PR DESCRIPTION
Hi,

I removed conflicted fields from the manifest. PlatformIO crawler automatically handles repository tags based on the version. See the library in PlatformIO Registry https://registry.platformio.org/packages/libraries/kitesurfer1404/WS2812FX