### PR TITLE
removed use of min/max macros

### DIFF
--- a/examples/esp8266_webinterface/esp8266_webinterface.ino
+++ b/examples/esp8266_webinterface/esp8266_webinterface.ino
@@ -66,10 +66,6 @@ extern const char main_js[];
   IPAddress subnet(255,255,255,0);
 #endif
 
-// QUICKFIX...See https://github.com/esp8266/Arduino/issues/263
-#define min(a,b) ((a)<(b)?(a):(b))
-#define max(a,b) ((a)>(b)?(a):(b))
-
 #define LED_PIN 2                       // 0 = GPIO0, 2=GPIO2
 #define LED_COUNT 24
 
@@ -243,7 +239,8 @@ void srv_handle_set() {
       if(server.arg(i)[0] == '-') {
         ws2812fx.setBrightness(ws2812fx.getBrightness() * 0.8);
       } else if(server.arg(i)[0] == ' ') {
-        ws2812fx.setBrightness(min(max(ws2812fx.getBrightness(), 5) * 1.2, 255));
+        int newBrightness = constrain(ws2812fx.getBrightness() * 1.2, 6, 255);
+        ws2812fx.setBrightness(newBrightness);
       } else { // set brightness directly
         uint8_t tmp = (uint8_t) strtol(server.arg(i).c_str(), NULL, 10);
         ws2812fx.setBrightness(tmp);
@@ -253,7 +250,8 @@ void srv_handle_set() {
 
     if(server.argName(i) == "s") {
       if(server.arg(i)[0] == '-') {
-        ws2812fx.setSpeed(max(ws2812fx.getSpeed(), 5) * 1.2);
+        int newSpeed = constrain(ws2812fx.getSpeed() * 1.2, 6, 65535);
+        ws2812fx.setSpeed(newSpeed);
       } else if(server.arg(i)[0] == ' ') {
         ws2812fx.setSpeed(ws2812fx.getSpeed() * 0.8);
       } else {

--- a/examples/tester_Dec2024.txt
+++ b/examples/tester_Dec2024.txt
@@ -1,0 +1,993 @@
+
+Compiling auto_mode_cycle/auto_mode_cycle.ino for Arduino Leonardo
+Sketch uses 19664 bytes (68%) of program storage space. Maximum is 28672 bytes.
+Global variables use 506 bytes (19%) of dynamic memory, leaving 2054 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling external_trigger/external_trigger.ino for Arduino Leonardo
+Sketch uses 19684 bytes (68%) of program storage space. Maximum is 28672 bytes.
+Global variables use 506 bytes (19%) of dynamic memory, leaving 2054 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling serial_control/serial_control.ino for Arduino Leonardo
+Sketch uses 23580 bytes (82%) of program storage space. Maximum is 28672 bytes.
+Global variables use 690 bytes (26%) of dynamic memory, leaving 1870 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_audio_reactive/ws2812fx_audio_reactive.ino for Arduino Leonardo
+Sketch uses 20294 bytes (70%) of program storage space. Maximum is 28672 bytes.
+Global variables use 526 bytes (20%) of dynamic memory, leaving 2034 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_custom_effect/ws2812fx_custom_effect.ino for Arduino Leonardo
+Sketch uses 20126 bytes (70%) of program storage space. Maximum is 28672 bytes.
+Global variables use 498 bytes (19%) of dynamic memory, leaving 2062 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_custom_effect2/ws2812fx_custom_effect2.ino for Arduino Leonardo
+Sketch uses 20008 bytes (69%) of program storage space. Maximum is 28672 bytes.
+Global variables use 513 bytes (20%) of dynamic memory, leaving 2047 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_custom_FastLED/ws2812fx_custom_FastLED.ino for Arduino Leonardo
+Sketch uses 19908 bytes (69%) of program storage space. Maximum is 28672 bytes.
+Global variables use 547 bytes (21%) of dynamic memory, leaving 2013 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+FastLED           3.9.4   /Users/klord/Desktop/Arduino/libraries/FastLED
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_limit_current/ws2812fx_limit_current.ino for Arduino Leonardo
+Sketch uses 23332 bytes (81%) of program storage space. Maximum is 28672 bytes.
+Global variables use 790 bytes (30%) of dynamic memory, leaving 1770 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_matrix/ws2812fx_matrix.ino for Arduino Leonardo
+Sketch uses 12466 bytes (43%) of program storage space. Maximum is 28672 bytes.
+Global variables use 434 bytes (16%) of dynamic memory, leaving 2126 bytes for local variables. Maximum is 2560 bytes.
+
+Used library         Version Path
+Adafruit GFX Library 1.11.11 /Users/klord/Desktop/Arduino/libraries/Adafruit_GFX_Library
+Adafruit BusIO       1.16.2  /Users/klord/Desktop/Arduino/libraries/Adafruit_BusIO
+Wire                 1.0     /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6/libraries/Wire
+SPI                  1.0     /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6/libraries/SPI
+Adafruit NeoMatrix   1.3.3   /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoMatrix
+Adafruit NeoPixel    1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_msgeq7/ws2812fx_msgeq7.ino for Arduino Leonardo
+Sketch uses 20342 bytes (70%) of program storage space. Maximum is 28672 bytes.
+Global variables use 522 bytes (20%) of dynamic memory, leaving 2038 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_overlay/ws2812fx_overlay.ino for Arduino Leonardo
+Sketch uses 19632 bytes (68%) of program storage space. Maximum is 28672 bytes.
+Global variables use 616 bytes (24%) of dynamic memory, leaving 1944 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_segment_sequence/ws2812fx_segment_sequence.ino for Arduino Leonardo
+Sketch uses 20432 bytes (71%) of program storage space. Maximum is 28672 bytes.
+Global variables use 528 bytes (20%) of dynamic memory, leaving 2032 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_segments/ws2812fx_segments.ino for Arduino Leonardo
+Sketch uses 19720 bytes (68%) of program storage space. Maximum is 28672 bytes.
+Global variables use 498 bytes (19%) of dynamic memory, leaving 2062 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_spi/ws2812fx_spi.ino for Arduino Leonardo
+Sketch uses 19940 bytes (69%) of program storage space. Maximum is 28672 bytes.
+Global variables use 499 bytes (19%) of dynamic memory, leaving 2061 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+SPI               1.0     /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6/libraries/SPI
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_transitions/ws2812fx_transitions.ino for Arduino Leonardo
+Sketch uses 20118 bytes (70%) of program storage space. Maximum is 28672 bytes.
+Global variables use 456 bytes (17%) of dynamic memory, leaving 2104 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling ws2812fx_virtual_strip/ws2812fx_virtual_strip.ino for Arduino Leonardo
+Sketch uses 19994 bytes (69%) of program storage space. Maximum is 28672 bytes.
+Global variables use 616 bytes (24%) of dynamic memory, leaving 1944 bytes for local variables. Maximum is 2560 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+arduino:avr   1.8.6   /Users/klord/Library/Arduino15/packages/arduino/hardware/avr/1.8.6
+exit status 0
+
+Compiling auto_mode_cycle/auto_mode_cycle.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling external_trigger/external_trigger.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling serial_control/serial_control.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_audio_reactive/ws2812fx_audio_reactive.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_custom_effect/ws2812fx_custom_effect.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_custom_effect2/ws2812fx_custom_effect2.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_custom_FastLED/ws2812fx_custom_FastLED.ino for ESP8266
+
+Used library      Version Path
+FastLED           3.9.4   /Users/klord/Desktop/Arduino/libraries/FastLED
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_limit_current/ws2812fx_limit_current.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_matrix/ws2812fx_matrix.ino for ESP8266
+
+Used library         Version Path
+Adafruit GFX Library 1.11.11 /Users/klord/Desktop/Arduino/libraries/Adafruit_GFX_Library
+Adafruit BusIO       1.16.2  /Users/klord/Desktop/Arduino/libraries/Adafruit_BusIO
+Wire                 1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/Wire
+SPI                  1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/SPI
+Adafruit NeoMatrix   1.3.3   /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoMatrix
+Adafruit NeoPixel    1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_msgeq7/ws2812fx_msgeq7.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_overlay/ws2812fx_overlay.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_segment_sequence/ws2812fx_segment_sequence.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_segments/ws2812fx_segments.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_spi/ws2812fx_spi.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+SPI               1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/SPI
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_transitions/ws2812fx_transitions.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_virtual_strip/ws2812fx_virtual_strip.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling auto_mode_cycle/auto_mode_cycle.ino for ESP32
+Sketch uses 304881 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22424 bytes (6%) of dynamic memory, leaving 305256 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling external_trigger/external_trigger.ino for ESP32
+Sketch uses 311069 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22512 bytes (6%) of dynamic memory, leaving 305168 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling serial_control/serial_control.ino for ESP32
+Sketch uses 320261 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22448 bytes (6%) of dynamic memory, leaving 305232 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_audio_reactive/ws2812fx_audio_reactive.ino for ESP32
+Sketch uses 324165 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22528 bytes (6%) of dynamic memory, leaving 305152 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_custom_effect/ws2812fx_custom_effect.ino for ESP32
+Sketch uses 317177 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22424 bytes (6%) of dynamic memory, leaving 305256 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_custom_effect2/ws2812fx_custom_effect2.ino for ESP32
+Sketch uses 317273 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22432 bytes (6%) of dynamic memory, leaving 305248 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_custom_FastLED/ws2812fx_custom_FastLED.ino for ESP32
+Sketch uses 325193 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22472 bytes (6%) of dynamic memory, leaving 305208 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+FastLED           3.9.4   /Users/klord/Desktop/Arduino/libraries/FastLED
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_limit_current/ws2812fx_limit_current.ino for ESP32
+Sketch uses 320213 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22448 bytes (6%) of dynamic memory, leaving 305232 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_matrix/ws2812fx_matrix.ino for ESP32
+Sketch uses 315497 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 21288 bytes (6%) of dynamic memory, leaving 306392 bytes for local variables. Maximum is 327680 bytes.
+
+Used library         Version Path
+Adafruit GFX Library 1.11.11 /Users/klord/Desktop/Arduino/libraries/Adafruit_GFX_Library
+Adafruit BusIO       1.16.2  /Users/klord/Desktop/Arduino/libraries/Adafruit_BusIO
+Wire                 3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Wire
+SPI                  3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/SPI
+Adafruit NeoMatrix   1.3.3   /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoMatrix
+Adafruit NeoPixel    1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_msgeq7/ws2812fx_msgeq7.ino for ESP32
+Sketch uses 324289 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22528 bytes (6%) of dynamic memory, leaving 305152 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_overlay/ws2812fx_overlay.ino for ESP32
+Sketch uses 304997 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22608 bytes (6%) of dynamic memory, leaving 305072 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_segment_sequence/ws2812fx_segment_sequence.ino for ESP32
+Sketch uses 318173 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22448 bytes (6%) of dynamic memory, leaving 305232 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_segments/ws2812fx_segments.ino for ESP32
+Sketch uses 316969 bytes (24%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22424 bytes (6%) of dynamic memory, leaving 305256 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_spi/ws2812fx_spi.ino for ESP32
+Sketch uses 309389 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22512 bytes (6%) of dynamic memory, leaving 305168 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+SPI               3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/SPI
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_transitions/ws2812fx_transitions.ino for ESP32
+Sketch uses 305305 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22344 bytes (6%) of dynamic memory, leaving 305336 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_virtual_strip/ws2812fx_virtual_strip.ino for ESP32
+Sketch uses 304969 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22608 bytes (6%) of dynamic memory, leaving 305072 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling auto_mode_cycle/auto_mode_cycle.ino for RP2040
+Sketch uses 73972 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11076 bytes (4%) of dynamic memory, leaving 251068 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling external_trigger/external_trigger.ino for RP2040
+Sketch uses 74244 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11080 bytes (4%) of dynamic memory, leaving 251064 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling serial_control/serial_control.ino for RP2040
+Sketch uses 76180 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11088 bytes (4%) of dynamic memory, leaving 251056 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_audio_reactive/ws2812fx_audio_reactive.ino for RP2040
+Sketch uses 74636 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11080 bytes (4%) of dynamic memory, leaving 251064 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_custom_effect/ws2812fx_custom_effect.ino for RP2040
+Sketch uses 74108 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11068 bytes (4%) of dynamic memory, leaving 251076 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_custom_effect2/ws2812fx_custom_effect2.ino for RP2040
+Sketch uses 74180 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11072 bytes (4%) of dynamic memory, leaving 251072 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_custom_FastLED/ws2812fx_custom_FastLED.ino for RP2040
+Sketch uses 74312 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11116 bytes (4%) of dynamic memory, leaving 251028 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+FastLED           3.9.4   /Users/klord/Desktop/Arduino/libraries/FastLED
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_limit_current/ws2812fx_limit_current.ino for RP2040
+Sketch uses 76148 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11092 bytes (4%) of dynamic memory, leaving 251052 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_matrix/ws2812fx_matrix.ino for RP2040
+Sketch uses 68032 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 10092 bytes (3%) of dynamic memory, leaving 252052 bytes for local variables. Maximum is 262144 bytes.
+
+Used library         Version Path
+Adafruit GFX Library 1.11.11 /Users/klord/Desktop/Arduino/libraries/Adafruit_GFX_Library
+Adafruit BusIO       1.16.2  /Users/klord/Desktop/Arduino/libraries/Adafruit_BusIO
+Wire                 1.0     /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0/libraries/Wire
+SPI                  1.0     /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0/libraries/SPI
+Adafruit NeoMatrix   1.3.3   /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoMatrix
+Adafruit NeoPixel    1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_msgeq7/ws2812fx_msgeq7.ino for RP2040
+Sketch uses 74684 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11084 bytes (4%) of dynamic memory, leaving 251060 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_overlay/ws2812fx_overlay.ino for RP2040
+Sketch uses 74092 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11276 bytes (4%) of dynamic memory, leaving 250868 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_segment_sequence/ws2812fx_segment_sequence.ino for RP2040
+Sketch uses 74380 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11080 bytes (4%) of dynamic memory, leaving 251064 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_segments/ws2812fx_segments.ino for RP2040
+Sketch uses 73940 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11068 bytes (4%) of dynamic memory, leaving 251076 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_spi/ws2812fx_spi.ino for RP2040
+Sketch uses 77056 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11484 bytes (4%) of dynamic memory, leaving 250660 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+SPI               1.0     /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0/libraries/SPI
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_transitions/ws2812fx_transitions.ino for RP2040
+Sketch uses 74300 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 10984 bytes (4%) of dynamic memory, leaving 251160 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling ws2812fx_virtual_strip/ws2812fx_virtual_strip.ino for RP2040
+Sketch uses 74060 bytes (3%) of program storage space. Maximum is 2093056 bytes.
+Global variables use 11276 bytes (4%) of dynamic memory, leaving 250868 bytes for local variables. Maximum is 262144 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+rp2040:rp2040 4.3.0   /Users/klord/Library/Arduino15/packages/rp2040/hardware/rp2040/4.3.0
+exit status 0
+
+Compiling esp8266_webinterface/esp8266_webinterface.ino for ESP8266
+
+Used library      Version Path
+ESP8266WiFi       1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi
+ESP8266WebServer  1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WebServer
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_alexa/ws2812fx_alexa.ino for ESP8266
+
+Used library      Version Path
+ESP8266WiFi       1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi
+Espalexa          2.7.0   /Users/klord/Desktop/Arduino/libraries/Espalexa
+ESP8266WebServer  1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WebServer
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_patterns_web/ws2812fx_patterns_web.ino for ESP8266
+
+Used library        Version Path
+WS2812FX            1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel   1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+EEPROM              1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/EEPROM
+ArduinoOTA          1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ArduinoOTA
+ESP8266WiFi         1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi
+ESPAsyncTCP         1.2.4   /Users/klord/Desktop/Arduino/libraries/ESPAsyncTCP
+ESP Async WebServer 3.3.23  /Users/klord/Desktop/Arduino/libraries/ESP_Async_WebServer
+Hash                1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/Hash
+ArduinoJson         7.2.1   /Users/klord/Desktop/Arduino/libraries/ArduinoJson
+ESP8266mDNS         1.2     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266mDNS
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_segments_OTA/ws2812fx_segments_OTA.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+ArduinoOTA        1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ArduinoOTA
+ESP8266WiFi       1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi
+ESP8266mDNS       1.2     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266mDNS
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_segments_web/ws2812fx_segments_web.ino for ESP8266
+
+Used library        Version Path
+WS2812FX            1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel   1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+EEPROM              1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/EEPROM
+ArduinoOTA          1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ArduinoOTA
+ESP8266WiFi         1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi
+ESPAsyncTCP         1.2.4   /Users/klord/Desktop/Arduino/libraries/ESPAsyncTCP
+ESP Async WebServer 3.3.23  /Users/klord/Desktop/Arduino/libraries/ESP_Async_WebServer
+Hash                1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/Hash
+ArduinoJson         7.2.1   /Users/klord/Desktop/Arduino/libraries/ArduinoJson
+ESP8266mDNS         1.2     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266mDNS
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_extData/ws2812fx_extData.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling esp8266_webinterface/esp8266_webinterface.ino for ESP32
+Sketch uses 983717 bytes (75%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 53432 bytes (16%) of dynamic memory, leaving 274248 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WiFi              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WiFi
+Networking        3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Network
+WebServer         3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WebServer
+FS                3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/FS
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_alexa/ws2812fx_alexa.ino for ESP32
+Sketch uses 1003645 bytes (76%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 48456 bytes (14%) of dynamic memory, leaving 279224 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WiFi              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WiFi
+Networking        3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Network
+Espalexa          2.7.0   /Users/klord/Desktop/Arduino/libraries/Espalexa
+WebServer         3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WebServer
+FS                3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/FS
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_patterns_web/ws2812fx_patterns_web.ino for ESP32
+Sketch uses 1104865 bytes (84%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 53648 bytes (16%) of dynamic memory, leaving 274032 bytes for local variables. Maximum is 327680 bytes.
+
+Used library        Version Path
+WS2812FX            1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel   1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+EEPROM              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/EEPROM
+ArduinoOTA          3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/ArduinoOTA
+Networking          3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Network
+Update              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Update
+AsyncTCP            1.1.4   /Users/klord/Desktop/Arduino/libraries/AsyncTCP
+WiFi                3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WiFi
+ESP Async WebServer 3.3.23  /Users/klord/Desktop/Arduino/libraries/ESP_Async_WebServer
+FS                  3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/FS
+ArduinoJson         7.2.1   /Users/klord/Desktop/Arduino/libraries/ArduinoJson
+ESPmDNS             3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/ESPmDNS
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_segments_OTA/ws2812fx_segments_OTA.ino for ESP32
+Sketch uses 991809 bytes (75%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 51400 bytes (15%) of dynamic memory, leaving 276280 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+ArduinoOTA        3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/ArduinoOTA
+Networking        3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Network
+Update            3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Update
+WiFi              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WiFi
+ESPmDNS           3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/ESPmDNS
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_segments_web/ws2812fx_segments_web.ino for ESP32
+Sketch uses 1171173 bytes (89%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 55736 bytes (17%) of dynamic memory, leaving 271944 bytes for local variables. Maximum is 327680 bytes.
+
+Used library        Version Path
+WS2812FX            1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel   1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+EEPROM              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/EEPROM
+ArduinoOTA          3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/ArduinoOTA
+Networking          3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Network
+Update              3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/Update
+AsyncTCP            1.1.4   /Users/klord/Desktop/Arduino/libraries/AsyncTCP
+WiFi                3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/WiFi
+ESP Async WebServer 3.3.23  /Users/klord/Desktop/Arduino/libraries/ESP_Async_WebServer
+FS                  3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/FS
+ArduinoJson         7.2.1   /Users/klord/Desktop/Arduino/libraries/ArduinoJson
+ESPmDNS             3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7/libraries/ESPmDNS
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_extData/ws2812fx_extData.ino for ESP32
+Sketch uses 304821 bytes (23%) of program storage space. Maximum is 1310720 bytes.
+Global variables use 22432 bytes (6%) of dynamic memory, leaving 305248 bytes for local variables. Maximum is 327680 bytes.
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+
+Used platform Version Path
+esp32:esp32   3.0.7   /Users/klord/Library/Arduino15/packages/esp32/hardware/esp32/3.0.7
+exit status 0
+
+Compiling ws2812fx_soundfx/ws2812fx_soundfx.ino for ESP8266
+
+Used library      Version Path
+WS2812FX          1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel 1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+ESP8266Audio      1.9.9   /Users/klord/Desktop/Arduino/libraries/ESP8266Audio
+LittleFS          0.1.0   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/LittleFS
+ESP8266HTTPClient 1.2     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266HTTPClient
+ESP8266WiFi       1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266WiFi
+SD                2.0.0   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/SD
+SDFS              0.1.0   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/SDFS
+SPI               1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/SPI
+ESP8266SdFat      2.1.1   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/ESP8266SdFat
+I2S               1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/I2S
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_dma/ws2812fx_dma.ino for ESP8266
+
+Used library          Version Path
+WS2812FX              1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+Adafruit NeoPixel     1.12.3  /Users/klord/Desktop/Arduino/libraries/Adafruit_NeoPixel
+NeoPixelBus by Makuna 2.8.3   /Users/klord/Desktop/Arduino/libraries/NeoPixelBus_by_Makuna
+SPI                   1.0     /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2/libraries/SPI
+
+Used platform   Version Path
+esp8266:esp8266 3.1.2   /Users/klord/Library/Arduino15/packages/esp8266/hardware/esp8266/3.1.2
+exit status 0
+
+Compiling ws2812fx_ATtiny/ws2812fx_ATtiny.ino for ATtiny412
+Sketch uses 3952 bytes (96%) of program storage space. Maximum is 4096 bytes.
+Global variables use 185 bytes (72%) of dynamic memory, leaving 71 bytes for local variables. Maximum is 256 bytes.
+
+Used library        Version Path
+WS2812FX            1.4.5   /Users/klord/Desktop/Arduino/libraries/WS2812FX
+tinyNeoPixel Static 2.0.7   /Users/klord/Library/Arduino15/packages/megaTinyCore/hardware/megaavr/2.6.10/libraries/tinyNeoPixel_Static
+
+Used platform        Version Path
+megaTinyCore:megaavr 2.6.10  /Users/klord/Library/Arduino15/packages/megaTinyCore/hardware/megaavr/2.6.10
+exit status 0

--- a/examples/ws2812fx_matrix/ws2812fx_matrix.ino
+++ b/examples/ws2812fx_matrix/ws2812fx_matrix.ino
@@ -64,7 +64,7 @@ void loop() {
     color_index = 0; // reset the rainbow color index
   }
   matrix.setTextColor(color_wheel(color_index));
-  color_index += max(1, 256 / scroll_limit);
+  color_index += (256 / scroll_limit) > 1 ? (256 / scroll_limit) : 1;
   matrix.show();
   delay(100);
 }

--- a/examples/ws2812fx_segments_web/ws2812fx_segments_web.ino
+++ b/examples/ws2812fx_segments_web/ws2812fx_segments_web.ino
@@ -41,11 +41,22 @@
 #define DYNAMIC_JSON_DOCUMENT_SIZE  2048 /* used by AsyncJson. Default is 1024, which is a little too small */
 
 #include <WS2812FX.h>
-#include <ESPAsyncWebSrv.h> /* https://github.com/me-no-dev/ESPAsyncWebServer */
-#include <AsyncJson.h>
-#include <ArduinoJson.h>
-#include <ArduinoOTA.h>
 #include <EEPROM.h>
+#include <ArduinoOTA.h>
+
+#ifdef ESP32
+  #include <AsyncTCP.h>
+  #include <WiFi.h>
+#elif defined(ESP8266)
+  #include <ESP8266WiFi.h>
+  #include <ESPAsyncTCP.h>
+#elif defined(TARGET_RP2040)
+  #include <WebServer.h>
+  #include <WiFi.h>
+#endif
+#include <ESPAsyncWebServer.h>
+#include <ArduinoJson.h>
+#include <AsyncJson.h>
 
 #include "bundle.css.h"
 #include "bundle.js.h"
@@ -262,7 +273,7 @@ void showReqParams(AsyncWebServerRequest * request) {
   Serial.println("HTTP request parameters:");
   int params = request->params();
   for (int i = 0; i < params; i++) {
-    AsyncWebParameter* p = request->getParam(i);
+    const AsyncWebParameter* p = request->getParam(i);
     if (p->isFile()) { //p->isPost() is also true
       Serial.printf("FILE[%s]: %s, size: %u\n", p->name().c_str(), p->value().c_str(), p->size());
     } else if (p->isPost()) {

--- a/extras/WS2812FX change log.txt
+++ b/extras/WS2812FX change log.txt
@@ -1,5 +1,14 @@
 WS2182FX Change Log
 
+
+v1.4.5 changes 12/01/2024
+-------------------------
+
+1) Removed use of min and max preprocessor macros, which were causing
+    compile issues for various board cores (notably ESP32 v2.0.x and
+	ESP32 v3.0.x). Goodbye, Farewell and Amen!
+
+
 v1.4.4 changes 06/16/2024
 -------------------------
 

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "name": "Harm Aldick",
     "url": "https://github.com/kitesurfer1404/WS2812FX"
   },
-  "version": "1.4.4",
+  "version": "1.4.5",
   "frameworks": "arduino",
   "platforms": "*",
   "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WS2812FX
-version=1.4.4
+version=1.4.5
 author=Harm Aldick
 maintainer=Harm Aldick
 sentence=WS2812 FX Library for Arduino and ESP microprocessors.

--- a/src/WS2812FX.cpp
+++ b/src/WS2812FX.cpp
@@ -79,7 +79,7 @@ bool WS2812FX::service() {
           SET_FRAME;
           doShow = true;
           uint16_t delay = (MODE_PTR(_seg->mode))();
-          _seg_rt->next_time = now + max(delay, SPEED_MIN);
+          _seg_rt->next_time = now + (delay > SPEED_MIN ? delay : SPEED_MIN);
           _seg_rt->counter_mode_call++;
         }
       }

--- a/src/WS2812FX.h
+++ b/src/WS2812FX.h
@@ -46,15 +46,7 @@
   #include <Adafruit_NeoPixel.h>
 #endif
 
-// include max macro for ESP boards
-#ifndef max
-#define max(a,b) \
-  ({ __typeof__ (a) _a = (a); \
-    __typeof__ (b) _b = (b); \
-    _a > _b ? _a : _b; })
-#endif
-
-#define DEFAULT_BRIGHTNESS (uint8_t)50
+#define DEFAULT_BRIGHTNESS (uint8_t)16 /* set default brightness quite low to minimize current draw on startup */
 #define DEFAULT_MODE       (uint8_t)0
 #define DEFAULT_SPEED      (uint16_t)1000
 #define DEFAULT_COLOR      (uint32_t)0xFF0000
@@ -163,7 +155,7 @@ class WS2812FX : public tinyNeoPixel {
     WS2812FX(uint16_t num_leds, uint8_t pin, neoPixelType type, byte* pixelPtr)
       : tinyNeoPixel(num_leds, pin, type, pixelPtr) {
 
-      brightness = 16;  // default the brightness quite low to limit the current draw
+      brightness = 8;  // default the brightness quite low to limit the current draw
 
 /* since an ATtiny is so memory constrained, we only allow one LED segment. Since the
    number of segments is fixed, we can initialize the segment variable in the class

--- a/src/custom/RainbowFireworks.h
+++ b/src/custom/RainbowFireworks.h
@@ -76,7 +76,8 @@ uint16_t rainbowFireworks(void) {
   }
 
   // randomly create a red pixel
-  for(uint16_t i=0; i<max(1, seglen/20); i++) {
+  uint16_t numPixels = seglen/20 > 1 ? seglen/20 : 1;
+  for(uint16_t i=0; i<numPixels; i++) {
     if(ws2812fx.random8(10) == 0) {
       uint16_t index = seg->start + 6 + ws2812fx.random16(seglen - 12);
       ws2812fx.setPixelColor(index, RED);

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -302,7 +302,8 @@ uint16_t WS2812FX::mode_theater_chase_rainbow(void) {
  */
 uint16_t WS2812FX::mode_running_lights(void) {
   uint8_t size = 1 << SIZE_OPTION;
-  uint8_t sineIncr = max((uint8_t)1, (256 / _seg_len) * size);
+  uint8_t sineIncr = (256 / _seg_len) * size;
+  sineIncr = sineIncr > 1 ? sineIncr : 1;
   for(uint16_t i=0; i < _seg_len; i++) {
     int lum = (int)sine8(((i + _seg_rt->counter_mode_step) * sineIncr));
     uint32_t color = color_blend(_seg->colors[0], _seg->colors[1], lum);
@@ -865,7 +866,8 @@ uint16_t WS2812FX::mode_rainbow_fireworks(void) {
 
   // occasionally create a random red pixel
   if(random8(4) == 0) {
-    uint16_t index = _seg->start + 6 + random16(max((uint8_t)1, _seg_len - 12));
+    uint16_t rand16 = random16(_seg_len - 12 > 1 ? _seg_len - 12 : 1);
+    uint16_t index = _seg->start + 6 + rand16;
     setRawPixelColor(index, RED); // set the raw pixel color (ignore global brightness)
     SET_CYCLE;
   }

--- a/src/modes_funcs.cpp
+++ b/src/modes_funcs.cpp
@@ -386,7 +386,8 @@ uint16_t WS2812FX::fireworks(uint32_t color) {
 
   uint8_t size = 2 << SIZE_OPTION;
   if(!_triggered) {
-    for(uint16_t i=0; i<max((uint8_t)1, _seg_len/20); i++) {
+    uint16_t numBursts = _seg_len/20 > 1 ? _seg_len/20 : 1;
+    for(uint16_t i=0; i<numBursts; i++) {
       if(random8(10) == 0) {
         uint16_t index = _seg->start + random16(_seg_len - size + 1);
         fill(color, index, size);
@@ -394,7 +395,8 @@ uint16_t WS2812FX::fireworks(uint32_t color) {
       }
     }
   } else {
-    for(uint16_t i=0; i<max((uint8_t)1, _seg_len/10); i++) {
+    uint16_t numBursts = _seg_len/10 > 1 ? _seg_len/10 : 1;
+    for(uint16_t i=0; i<numBursts; i++) {
       uint16_t index = _seg->start + random16(_seg_len - size + 1);
       fill(color, index, size);
       SET_CYCLE;
@@ -408,14 +410,21 @@ uint16_t WS2812FX::fireworks(uint32_t color) {
  * Fire flicker function
  */
 uint16_t WS2812FX::fire_flicker(int rev_intensity) {
-  byte w = (_seg->colors[0] >> 24) & 0xFF;
-  byte r = (_seg->colors[0] >> 16) & 0xFF;
-  byte g = (_seg->colors[0] >>  8) & 0xFF;
-  byte b = (_seg->colors[0]        & 0xFF);
-  byte lum = max(w, max(r, max(g, b))) / rev_intensity;
+  uint8_t w = (_seg->colors[0] >> 24) & 0xFF;
+  uint8_t r = (_seg->colors[0] >> 16) & 0xFF;
+  uint8_t g = (_seg->colors[0] >>  8) & 0xFF;
+  uint8_t b = (_seg->colors[0]        & 0xFF);
+  uint8_t maxLum = g > b ? g : b;
+  maxLum = maxLum > r ? maxLum : r;
+  maxLum = maxLum > w ? maxLum : w;
+  uint8_t lum = maxLum / rev_intensity;
   for(uint16_t i=_seg->start; i <= _seg->stop; i++) {
-    int flicker = random8(lum);
-    setPixelColor(i, max(r - flicker, 0), max(g - flicker, 0), max(b - flicker, 0), max(w - flicker, 0));
+    uint8_t flicker = random8(lum);
+    uint8_t r2 = (r - flicker) > 0 ? (r - flicker) : 0;
+    uint8_t g2 = (g - flicker) > 0 ? (g - flicker) : 0;
+    uint8_t b2 = (b - flicker) > 0 ? (b - flicker) : 0;
+    uint8_t w2 = (w - flicker) > 0 ? (w - flicker) : 0;
+    setPixelColor(i, r2, g2, b2, w2);
   }
 
   SET_CYCLE;


### PR DESCRIPTION
Removed use of min and max preprocessor macros, which were causing issues with ESP32 depending on the IDF version you were using.